### PR TITLE
Fix: spelling of environment in build-the-tool skill

### DIFF
--- a/.agents/skills/build-the-tool/SKILL.md
+++ b/.agents/skills/build-the-tool/SKILL.md
@@ -7,7 +7,7 @@ To build the tool, follow these steps:
 
 1. Make sure the clang++ compiler is available on your system. You can check this by running `clang++ --version` in your terminal. The current supported version is 19.
 
-2. If not available, a conda enviroment like the following can be loaded:
+2. If not available, a conda environment like the following can be loaded:
 
 ```bash
 source ~/.bashrc


### PR DESCRIPTION
## Summary

Corrects a misspelling in `.agents/skills/build-the-tool/SKILL.md` (`conda enviroment` → `conda environment`).

The later step already uses the correct spelling (`PATH environment variable`). The misspelling is in the setup instructions agents follow when clang++ is missing.

Docs-only, no build or code changes.